### PR TITLE
Use the class defined that inherits from Setler::Settings since it may h...

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -3,3 +3,4 @@ Andy Lindeman github.com/alindeman
 Phil Ostler github.com/philostler
 Rachel Heaton github.com/rheaton
 Corey Innis github.com/coreyti
+Steven Harman github.com/stevenharman

--- a/contributors.txt
+++ b/contributors.txt
@@ -2,3 +2,4 @@ Chris Kelly github.com/ckdake
 Andy Lindeman github.com/alindeman
 Phil Ostler github.com/philostler
 Rachel Heaton github.com/rheaton
+Corey Innis github.com/coreyti

--- a/lib/generators/setler/setler_generator.rb
+++ b/lib/generators/setler/setler_generator.rb
@@ -2,13 +2,13 @@ require 'rails/generators/migration'
 
 class SetlerGenerator < Rails::Generators::NamedBase
   include Rails::Generators::Migration
-  
+
   argument :name, type: :string, default: "settings"
-  
+
   source_root File.expand_path('../templates', __FILE__)
-  
+
   @@migrations = false
-  
+
   def self.next_migration_number(dirname)
     if ActiveRecord::Base.timestamped_migrations
       if @@migrations
@@ -21,7 +21,7 @@ class SetlerGenerator < Rails::Generators::NamedBase
       "%.3d" % (current_migration_number(dirname) + 1)
     end
   end
-  
+
   def generate_model
     template "model.rb", File.join("app/models",class_path,"#{file_name}.rb"), force: true
     migration_template "migration.rb", "db/migrate/setler_create_#{table_name}.rb"

--- a/lib/generators/setler/templates/migration.rb
+++ b/lib/generators/setler/templates/migration.rb
@@ -7,7 +7,7 @@ class SetlerCreate<%= table_name.camelize %> < ActiveRecord::Migration
       t.string  :thing_type, limit: 30, null: true
       t.timestamps
     end
-    
+
     add_index :<%= table_name %>, [ :thing_type, :thing_id, :var ], unique: true
   end
 

--- a/lib/setler/active_record.rb
+++ b/lib/setler/active_record.rb
@@ -1,11 +1,11 @@
 module Setler
   module ActiveRecord
-    
+
     def has_setler(scopename = 'settings')
       define_method scopename do
         Setler::ScopedSettings.for_thing(self, scopename)
       end
     end
-    
+
   end
 end

--- a/lib/setler/scoped_settings.rb
+++ b/lib/setler/scoped_settings.rb
@@ -2,12 +2,14 @@ module Setler
   class ScopedSettings < Settings
     def self.for_thing(object, scopename)
       self.table_name = scopename
+      @setler_active_record_class = eval(scopename.to_s.camelize)
+
       @object = object
       self
     end
 
     def self.thing_scoped
-      self.base_class.where(thing_type: @object.class.base_class.to_s, thing_id: @object.id)
+      @setler_active_record_class.where(thing_type: @object.class.base_class.to_s, thing_id: @object.id)
     end
 
   end

--- a/lib/setler/scoped_settings.rb
+++ b/lib/setler/scoped_settings.rb
@@ -5,10 +5,10 @@ module Setler
       @object = object
       self
     end
-    
+
     def self.thing_scoped
       self.base_class.where(thing_type: @object.class.base_class.to_s, thing_id: @object.id)
     end
-    
+
   end
 end

--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -3,8 +3,9 @@ module Setler
     serialize :value
     self.abstract_class = true
     
-    cattr_accessor :defaults
-    @@defaults = {}.with_indifferent_access
+    def self.defaults
+      @defaults ||= {}.with_indifferent_access
+    end
     
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
@@ -22,7 +23,7 @@ module Setler
 
     def self.[](var)
       the_setting = thing_scoped.find_by_var(var.to_s)
-      the_setting.present? ? the_setting.value : @@defaults[var]
+      the_setting.present? ? the_setting.value : defaults[var]
     end
 
     def self.[]=(var, value)
@@ -48,7 +49,7 @@ module Setler
     end
     
     def self.all
-      @@defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
+      defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
     end
     
     def self.thing_scoped

--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -2,11 +2,11 @@ module Setler
   class Settings < ActiveRecord::Base
     serialize :value
     self.abstract_class = true
-    
+
     def self.defaults
       @defaults ||= {}.with_indifferent_access
     end
-    
+
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
       if respond_to?(method)
@@ -47,15 +47,15 @@ module Setler
         raise SettingNotFound, "Setting variable \"#{var_name}\" not found"
       end
     end
-    
+
     def self.all
       defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
     end
-    
+
     def self.thing_scoped
       self.where(thing_type: nil, thing_id: nil)
     end
-    
+
   end
-  
+
 end

--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -2,11 +2,10 @@ module Setler
   class Settings < ActiveRecord::Base
     serialize :value
     self.abstract_class = true
-
-    def self.defaults
-      @defaults ||= {}.with_indifferent_access
-    end
-
+    
+    cattr_accessor :defaults
+    @@defaults = {}.with_indifferent_access
+    
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
       if respond_to?(method)
@@ -23,7 +22,7 @@ module Setler
 
     def self.[](var)
       the_setting = thing_scoped.find_by_var(var.to_s)
-      the_setting.present? ? the_setting.value : defaults[var]
+      the_setting.present? ? the_setting.value : @@defaults[var]
     end
 
     def self.[]=(var, value)
@@ -49,7 +48,7 @@ module Setler
     end
 
     def self.all
-      defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
+      @@defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
     end
 
     def self.thing_scoped

--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -2,10 +2,10 @@ module Setler
   class Settings < ActiveRecord::Base
     serialize :value
     self.abstract_class = true
-    
+
     cattr_accessor :defaults
     @@defaults = {}.with_indifferent_access
-    
+
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
       if respond_to?(method)
@@ -34,7 +34,7 @@ module Setler
         var.to_s,
         @object.try(:class).try(:base_class).try(:to_s),
         @object.try(:id)
-      ).update_attribute(:value, value)
+      ).update_attributes({ :value => value })
     end
 
     def self.destroy(var_name)
@@ -56,5 +56,4 @@ module Setler
     end
 
   end
-
 end

--- a/lib/setler/version.rb
+++ b/lib/setler/version.rb
@@ -1,3 +1,3 @@
 module Setler
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/lib/setler/version.rb
+++ b/lib/setler/version.rb
@@ -1,3 +1,3 @@
 module Setler
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/lib/setler/version.rb
+++ b/lib/setler/version.rb
@@ -1,3 +1,3 @@
 module Setler
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -114,7 +114,7 @@ class ::SettingsTest < Test::Unit::TestCase
   def test_user_settings_all
     ::Settings.destroy_all
     user = User.create name: 'user 1'
-    assert_equal ::Settings.all, user.preferences.all
+    assert_equal ::Preferences.all, user.preferences.all
     user.preferences.likes_bacon = true
     user.preferences.really_likes_bacon = true
     assert user.preferences.all['likes_bacon']
@@ -145,5 +145,17 @@ class ::SettingsTest < Test::Unit::TestCase
     assert_raise Setler::SettingNotFound do
       ::Settings.destroy :not_a_setting
     end
+  end
+
+  def test_implementations_are_independent
+    ::Preferences.create(:var => 'test',  :value => 'preferences foo')
+    ::Preferences.create(:var => 'test2', :value => 'preferences bar')
+
+    assert_not_equal ::Settings.defaults, ::Preferences.defaults
+
+    assert_equal 'foo', ::Settings[:test]
+    assert_equal 'bar', ::Settings[:test2]
+    assert_equal 'preferences foo', ::Preferences[:test]
+    assert_equal 'preferences bar', ::Preferences[:test2]
   end
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -2,41 +2,41 @@ require 'test_helper'
 
 class ::SettingsTest < Test::Unit::TestCase
   setup_db
-  
+
   def setup
     ::Settings.create(:var => 'test',  :value => 'foo')
     ::Settings.create(:var => 'test2', :value => 'bar')
   end
-  
+
   def teardown
     ::Settings.delete_all
     ::Preferences.delete_all
   end
-  
+
   def test_defaults
     ::Settings.defaults[:foo] = 'default foo'
-    
+
     assert_equal 'default foo', ::Settings.foo
-    
+
     ::Settings.foo = 'bar'
     assert_equal 'bar', ::Settings.foo
   end
-  
+
   def tests_defaults_false
     ::Settings.defaults[:foo] = false
     assert_equal false, ::Settings.foo
   end
-  
+
   def test_get
     assert_equal 'foo', ::Settings.test
     assert_equal 'bar', ::Settings.test2
   end
-  
+
   def test_get_with_array_syntax
     assert_equal 'foo', ::Settings["test"]
     assert_equal 'bar', ::Settings[:test2]
   end
-  
+
   def test_update
     ::Settings.test = '321'
     assert_equal '321', ::Settings.test
@@ -56,33 +56,33 @@ class ::SettingsTest < Test::Unit::TestCase
   def test_update_with_array_syntax
     ::Settings["test"] = '321'
     assert_equal '321', ::Settings.test
-  
+
     ::Settings[:test] = '567'
     assert_equal '567', ::Settings.test
   end
-  
+
   def test_create
     ::Settings.onetwothree = '123'
     assert_equal '123', ::Settings.onetwothree
   end
-  
+
   def test_complex_serialization
     complex = [1, '2', {:three => true}]
     ::Settings.complex = complex
     assert_equal complex, ::Settings.complex
   end
-  
+
   def test_serialization_of_float
     ::Settings.float = 0.01
     ::Settings.reload
     assert_equal 0.01, ::Settings.float
     assert_equal 0.02, ::Settings.float * 2
   end
-  
+
   def test_all
     assert_equal({ "test2" => "bar", "test" => "foo" }, ::Settings.all)
   end
-  
+
   def test_destroy
     assert_not_nil ::Settings.test
     ::Settings.destroy :test
@@ -101,7 +101,7 @@ class ::SettingsTest < Test::Unit::TestCase
     ::Settings.testing = '123'
     assert_nil ::Preferences.testing
   end
-  
+
   def test_user_has_setler
     user = User.create name: 'user 1'
     assert_nil user.preferences.likes_bacon
@@ -110,7 +110,7 @@ class ::SettingsTest < Test::Unit::TestCase
     user.preferences.destroy :likes_bacon
     assert_nil user.preferences.likes_bacon
   end
-   
+
   def test_user_settings_all
     ::Settings.destroy_all
     user = User.create name: 'user 1'
@@ -122,7 +122,7 @@ class ::SettingsTest < Test::Unit::TestCase
     assert user.preferences.all['really_likes_bacon']
     assert !::Settings.all['really_likes_bacon']
   end
-  
+
   def test_user_settings_override_defaults
     ::Settings.defaults[:foo] = false
     user = User.create name: 'user 1'
@@ -132,13 +132,13 @@ class ::SettingsTest < Test::Unit::TestCase
     user.preferences.foo = false
     assert !user.preferences.foo
   end
-  
+
   def test_user_preferences_has_defaults
     ::Preferences.defaults[:foo] = true
     user = User.create name: 'user 1'
     assert user.preferences.foo
   end
-  
+
   # def test_user_has_settings_for
   #   user1 = User.create name: 'awesome user'
   #   user2 = User.create name: 'bad user'

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -133,6 +133,12 @@ class ::SettingsTest < Test::Unit::TestCase
     assert !user.preferences.foo
   end
   
+  def test_user_preferences_has_defaults
+    ::Preferences.defaults[:foo] = true
+    user = User.create name: 'user 1'
+    assert user.preferences.foo
+  end
+  
   # def test_user_has_settings_for
   #   user1 = User.create name: 'awesome user'
   #   user2 = User.create name: 'bad user'
@@ -148,8 +154,8 @@ class ::SettingsTest < Test::Unit::TestCase
   end
 
   def test_implementations_are_independent
-    ::Preferences.create(:var => 'test',  :value => 'preferences foo')
-    ::Preferences.create(:var => 'test2', :value => 'preferences bar')
+    ::Preferences.create var: 'test',  value: 'preferences foo'
+    ::Preferences.create var: 'test2', value: 'preferences bar'
 
     assert_not_equal ::Settings.defaults, ::Preferences.defaults
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ def setup_db
       t.timestamps
     end
     add_index :settings, [ :thing_type, :thing_id, :var ], :unique => true
-    
+
     create_table :preferences do |t|
       t.string :var, :null => false
       t.text   :value, :null => true
@@ -46,7 +46,7 @@ def setup_db
       t.timestamps
     end
     add_index :preferences, [ :thing_type, :thing_id, :var ], :unique => true
-    
+
     create_table :users do |t|
       t.string :name
     end


### PR DESCRIPTION
...ave customizations on it

Customizations such as changing the database connection with dbcharmer.

Hey, so I think I figured out why setler wasn't working... when ScopedSettings was doing the `where` query, it was just using Setler::Settings' active record connection rather than looking up the class that was defined to inherit from Setler::Settings like ReviewFlags in our project, so the dbcharmer connection in ReviewFlags wasn't being used.

I'm really not sure how to test this though, within setler, without mocking a bunch of stuff and/or setting up a model with a different database connection :-/ Do you have any ideas?
